### PR TITLE
Compatibility with IDF >5.0

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,0 +1,3 @@
+dependencies:
+  espressif/esp32-camera:
+    version: '*'

--- a/main/main.c
+++ b/main/main.c
@@ -115,7 +115,7 @@ esp_err_t jpg_stream_httpd_handler(httpd_req_t *req){
         int64_t frame_time = fr_end - last_frame;
         last_frame = fr_end;
         frame_time /= 1000;
-        ESP_LOGI(TAG, "MJPG: %luKB %lums (%.1fps)",
+        ESP_LOGI(TAG, "MJPG: %luKB %lums (%.1ffps)",
             (uint32_t)(_jpg_buf_len/1024),
             (uint32_t)frame_time, 1000.0 / (uint32_t)frame_time);
     }

--- a/main/main.c
+++ b/main/main.c
@@ -115,7 +115,7 @@ esp_err_t jpg_stream_httpd_handler(httpd_req_t *req){
         int64_t frame_time = fr_end - last_frame;
         last_frame = fr_end;
         frame_time /= 1000;
-        ESP_LOGI(TAG, "MJPG: %uKB %ums (%.1ffps)",
+        ESP_LOGI(TAG, "MJPG: %luKB %lums (%.1fps)",
             (uint32_t)(_jpg_buf_len/1024),
             (uint32_t)frame_time, 1000.0 / (uint32_t)frame_time);
     }


### PR DESCRIPTION
ESP-IDF 5.0 and above has changed int32_t from `int` to `long int`, so the FPS parameters have to be adjusted.

Additionally, esp_camera.h could not be found when compiling the repo out of the box. In the `esp32-camera` example there is an `idf_component.yml` file that defines a dependency to the component and that fixed in my case, so I added it. Maybe it's an issue on my end but since the example repo does it this way..